### PR TITLE
update SYNOPSIS to use 'run_me' method

### DIFF
--- a/lib/Test/Routine.pm
+++ b/lib/Test/Routine.pm
@@ -40,7 +40,7 @@ B<The interface of Test::Routine is still open to some changes.>
     is( $self->fixture->things_done, 1, "we have done one thing already");
   };
 
-  test_me;
+  run_me;
   done_testing;
 
 =head1 DESCRIPTION


### PR DESCRIPTION
The SYNOPSIS in Routine.pm has a 'test_me' method, but the method was actually named 'run_me'.

Thanks for this module, it's sweeet!
