### PR TITLE
Beginnings of xUnit style magic auto clearing

### DIFF
--- a/lib/Test/Routine/AutoClear.pm
+++ b/lib/Test/Routine/AutoClear.pm
@@ -1,0 +1,21 @@
+package Test::Routine::Meta::Attribute::Trait::AutoClear;
+use Moose::Role;
+
+package Moose::Meta::Attribute::Custom::Trait::AutoClear;
+sub register_implementation {
+    'Test::Routine::Meta::Attribute::Trait::AutoClear';
+}
+
+package Test::Routine::AutoClear;
+use Moose::Role;
+
+after run_test => sub {
+    my $self = shift;
+
+    $_->clear_value($self) foreach grep {
+        $_->does( 'Test::Routine::Meta::Attribute::Trait::AutoClear' )
+    } $self->meta->get_all_attributes;
+};
+
+1;
+

--- a/lib/Test/Routine/xUnitish.pm
+++ b/lib/Test/Routine/xUnitish.pm
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+package Test::Routine::xUnitish;
+
+use Test::Routine ();
+use Moose::Exporter;
+
+Moose::Exporter->setup_import_methods(
+    with_meta => [qw{has}],
+    also => 'Test::Routine',
+);
+
+sub init_meta {
+    my($class, %arg) = @_;
+
+    my $meta = Moose::Role->init_meta(%arg);
+    my $role = $arg{for_class};
+    Moose::Util::apply_all_roles($role, 'Test::Routine::AutoClear');
+
+    return $meta;
+}
+
+sub has {
+    my($meta, $name, %options) = @_;
+
+    if (delete $options{auto_clear}) {
+        push @{$options{traits}}, 'AutoClear'
+    }
+
+    $meta->add_attribute(
+        $name,
+        %options,
+    );
+}
+1;

--- a/t/autoclear.t
+++ b/t/autoclear.t
@@ -1,0 +1,33 @@
+use Test::Routine;
+use Test::Routine::Util;
+use Test::More;
+with 'Test::Routine::AutoClear';
+
+use namespace::autoclean;
+
+has counter => (
+    is => 'rw',
+    isa => 'Int',
+    default => 0,
+    lazy => 1,
+    traits => [qw(AutoClear)],
+);
+
+test "first" => sub {
+    my($self) = @_;
+
+    is($self->counter, 0, "Always starting from zero");
+    $self->counter( 1 );
+    is($self->counter, 1, "And going to 1");
+};
+
+test "second" => sub {
+    my($self) = @_;
+
+    is($self->counter, 0, "Always starting from zero");
+    $self->counter( 1 );
+    is($self->counter, 1, "And going to 1");
+};
+
+run_me;
+done_testing;

--- a/t/xunitish.t
+++ b/t/xunitish.t
@@ -1,0 +1,32 @@
+use Test::Routine::xUnitish;
+use Test::Routine::Util;
+use Test::More;
+
+use namespace::autoclean;
+
+has counter => (
+    is => 'rw',
+    isa => 'Int',
+    default => 0,
+    lazy => 1,
+    auto_clear => 1,
+);
+
+test "first" => sub {
+    my($self) = @_;
+
+    is($self->counter, 0, "Always starting from zero");
+    $self->counter( 1 );
+    is($self->counter, 1, "And going to 1");
+};
+
+test "second" => sub {
+    my($self) = @_;
+
+    is($self->counter, 0, "Always starting from zero");
+    $self->counter( 1 );
+    is($self->counter, 1, "And going to 1");
+};
+
+run_me;
+done_testing;


### PR DESCRIPTION
To get auto clearing in on an attribute:

```
use Test::Routine
with 'Test::Routine::AutoClear'

has counter => (
    is => 'rw',
    default => 0,
    lazy => 1,
    traits => [qw(AutoClear)],
);
```

And as if by magic, the counter will get cleared after every test.

I'm not sure if this is the final interface. I'm wondering if:

```
use Test::Routine::xUnitish;

has counter => (
    default => 0,
    auto_clear => 1,
);

...
```

Might not be a better interface...
