### PR TITLE
remove "fresh_instance" and add startup/shutdown

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - remove fresh_instance; it wasn't documented, and it probably was not
+          going to work out
+        - the Runner no longer caches the test_instance, so its BUILD and
+          DEMOLISH should now be called usefully
+        - Test::Routine::Common now adds stub BUILD and DEMOLISH so you can use
+          method modifiers on them
 
 0.024     2017-01-16 13:03:18-05:00 America/New_York
         - tests are now run with Test::Abortable's subtest() instead of

--- a/lib/Test/Routine/Common.pm
+++ b/lib/Test/Routine/Common.pm
@@ -15,6 +15,9 @@ use Test2::API 1.302045 ();
 
 use namespace::autoclean;
 
+sub test_routine_startup  {}
+sub test_routine_shutdown {}
+
 sub run_test {
   my ($self, $test) = @_;
 

--- a/lib/Test/Routine/Common.pm
+++ b/lib/Test/Routine/Common.pm
@@ -15,8 +15,11 @@ use Test2::API 1.302045 ();
 
 use namespace::autoclean;
 
-sub test_routine_startup  {}
-sub test_routine_shutdown {}
+sub BUILD {
+}
+
+sub DEMOLISH {
+}
 
 sub run_test {
   my ($self, $test) = @_;

--- a/lib/Test/Routine/Runner.pm
+++ b/lib/Test/Routine/Runner.pm
@@ -103,9 +103,12 @@ sub run {
   } @tests;
 
   Test2::API::run_subtest($self->description, sub {
+    my $test_instance = $self->test_instance;
+    $test_instance->test_routine_startup;
     for my $test (@ordered_tests) {
-      $self->test_instance->run_test( $test );
+      $test_instance->run_test( $test );
     }
+    $test_instance->test_routine_shutdown;
   });
 }
 

--- a/lib/Test/Routine/Runner.pm
+++ b/lib/Test/Routine/Runner.pm
@@ -56,8 +56,9 @@ coerce 'Test::Routine::_InstanceBuilder',
 has test_instance => (
   is   => 'ro',
   does => 'Test::Routine::Common',
+  lazy => 1,
   init_arg   => undef,
-  lazy_build => 1,
+  builder    => '_build_test_instance',
 );
 
 has _instance_builder => (
@@ -76,12 +77,6 @@ has description => (
   is  => 'ro',
   isa => 'Str',
   required => 1,
-);
-
-has fresh_instance => (
-  is  => 'ro',
-  isa => 'Bool',
-  default => 0,
 );
 
 sub run {
@@ -110,7 +105,6 @@ sub run {
   Test2::API::run_subtest($self->description, sub {
     for my $test (@ordered_tests) {
       $self->test_instance->run_test( $test );
-      $self->clear_test_instance if $self->fresh_instance;
     }
   });
 }

--- a/lib/Test/Routine/Runner.pm
+++ b/lib/Test/Routine/Runner.pm
@@ -53,14 +53,6 @@ coerce 'Test::Routine::_InstanceBuilder',
   from 'Test::Routine::_Instance',
   via  { my $instance = $_; sub { $instance } };
 
-has test_instance => (
-  is   => 'ro',
-  does => 'Test::Routine::Common',
-  lazy => 1,
-  init_arg   => undef,
-  builder    => '_build_test_instance',
-);
-
 has _instance_builder => (
   is  => 'ro',
   isa => 'Test::Routine::_InstanceBuilder',
@@ -69,7 +61,7 @@ has _instance_builder => (
   init_arg => 'instance_from',
   required => 1,
   handles  => {
-    '_build_test_instance' => 'execute_method',
+    'build_test_instance' => 'execute_method',
   },
 );
 
@@ -82,10 +74,10 @@ has description => (
 sub run {
   my ($self) = @_;
 
-  my $thing = $self->test_instance;
+  my $test_instance = $self->build_test_instance;
 
   my @tests = grep { Moose::Util::does_role($_, 'Test::Routine::Test::Role') }
-              $thing->meta->get_all_methods;
+              $test_instance->meta->get_all_methods;
 
   my $re = $ENV{TEST_METHOD};
   if (defined $re and length $re) {
@@ -103,12 +95,9 @@ sub run {
   } @tests;
 
   Test2::API::run_subtest($self->description, sub {
-    my $test_instance = $self->test_instance;
-    $test_instance->test_routine_startup;
     for my $test (@ordered_tests) {
       $test_instance->run_test( $test );
     }
-    $test_instance->test_routine_shutdown;
   });
 }
 


### PR DESCRIPTION
`fresh_instance` was never used and, I think, was a bad idea.

startup/shutdown may want different names, but make it possible to get a message from the Runner when you're about to run your tests, and then when you're done.  It's useful for clearing data that needs to be cleaned up between runs or before shutdown.

**WIP?**