### PR TITLE
Add a way to list known tests of a file

### DIFF
--- a/lib/Test/Routine/Runner.pm
+++ b/lib/Test/Routine/Runner.pm
@@ -79,6 +79,19 @@ sub run {
   my @tests = grep { Moose::Util::does_role($_, 'Test::Routine::Test::Role') }
               $test_instance->meta->get_all_methods;
 
+  if ($ENV{TR_LIST_TEST_METHODS}) {
+    my $sq = eval {
+      require String::ShellQuote;
+      \&String::ShellQuote::shell_quote;
+    } || sub { $_[0] };
+
+    print "Tests:\n";
+
+    print "\t" . $sq->($_->name) . "\n" for @tests;
+
+    exit;
+  }
+
   my $re = $ENV{TEST_METHOD};
   if (defined $re and length $re) {
     my $filter = try { qr/$re/ } # compile the the regex separately ...


### PR DESCRIPTION
Usage:

  TR_LIST_TEST_METHODS=1 perl t/foo.t

Output (if String::ShellQuote is available):

  Tests:
    'sample test a'
    'sample test b'

Output (if String::ShellQuote isn't available):

  Tests:
    sample test a
    sample test b

The String::ShellQuote variant exists so you can easily run
that test by copying the given string